### PR TITLE
Update generator-lib.ts

### DIFF
--- a/src/generator-lib.ts
+++ b/src/generator-lib.ts
@@ -39,7 +39,7 @@ function makeFieldRules(fieldName: string, definition: Definition): string {
 }
 
 function makeField(fieldName: string, definition: Definition): string {
-  return `${fieldName}: new FormControl(null, [${makeFieldRules(fieldName, definition)}])`;
+  return `${fieldName}: new FormControl(undefined, [${makeFieldRules(fieldName, definition)}])`;
 }
 
 function makeFieldsBody(definition: Definition): string[] {


### PR DESCRIPTION
Use undefined as default value instead of null as htt-client serializes nulls and sends them in the http request which may cause problems in the back end while de-serializing the nulls