### PR TITLE
Fix failure of prettier on unquoted fieldNames containing '-'

### DIFF
--- a/src/generator-lib.ts
+++ b/src/generator-lib.ts
@@ -49,7 +49,7 @@ function makeFieldRules(fieldName: string, definition: Definition): string {
 }
 
 function makeField(fieldName: string, definition: Definition): string {
-  return `${fieldName}: new FormControl(null, [${makeFieldRules(fieldName, definition)}])`;
+  return `"${fieldName}": new FormControl(null, [${makeFieldRules(fieldName, definition)}])`;
 }
 
 function makeFieldsBody(definition: Definition): string[] {


### PR DESCRIPTION
Prettier fails with a SyntaxError: ',' expected when it encounters an unquoted field name in the form control. Simply quoting all field names fixes the issue. Prettier then keeps or removes the quotes automatically, as needed.