### PR TITLE
feat: convert default value spec to form value

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -6,7 +6,7 @@ Run the following from the `/demo` directory:
 
 ```bash
 npm install
-npm run generate:form
-ng build form
+npm run generate:forms
+ng build forms
 ng serve
 ```

--- a/demo/projects/forms/src/lib/myApi.ts
+++ b/demo/projects/forms/src/lib/myApi.ts
@@ -40,5 +40,6 @@ export const addressModelForm = new FormGroup({
     Validators.required,
     Validators.pattern(/^[\w\@\!\#\%\&\'\*\+\-\/\=\?\`\{\|\}\~\.]+$/),
     Validators.email
-  ])
+  ]),
+  country: new FormControl('Singapore', [Validators.required, Validators.minLength(1)])
 });

--- a/demo/swagger.json
+++ b/demo/swagger.json
@@ -41,7 +41,7 @@
   },
   "definitions": {
     "AddressModel": {
-      "required": ["firstName", "lastName", "address", "city", "postalCode", "emailAddress"],
+      "required": ["firstName", "lastName", "address", "city", "postalCode", "emailAddress", "country"],
       "type": "object",
       "properties": {
         "firstName": {
@@ -84,6 +84,11 @@
           "format": "email",
           "pattern": "^[\\w\\@\\!\\#\\%\\&\\'\\*\\+\\-\\/\\=\\?\\`\\{\\|\\}\\~\\.]+$",
           "type": "string"
+        },
+        "country": {
+          "type": "string",
+          "minLength": 1,
+          "default": "Singapore"
         }
       }
     }

--- a/demo/swagger.yaml
+++ b/demo/swagger.yaml
@@ -48,6 +48,7 @@ definitions:
       - city
       - postalCode
       - emailAddress
+      - country
     type: object
     properties:
       firstName:
@@ -84,3 +85,7 @@ definitions:
         format: email
         pattern: '^[\w\@\!\#\%\&\''\*\+\-\/\=\?\`\{\|\}\~\.]+$'
         type: string
+      country:
+        type: string
+        minLength: 1
+        default: 'Singapore',

--- a/src/generator-lib.ts
+++ b/src/generator-lib.ts
@@ -49,7 +49,8 @@ function makeFieldRules(fieldName: string, definition: Definition): string {
 }
 
 function makeField(fieldName: string, definition: Definition): string {
-  return `"${fieldName}": new FormControl(null, [${makeFieldRules(fieldName, definition)}])`;
+  const value = 'default' in definition.properties[fieldName] ? `'${definition.properties[fieldName].default}'` : null;
+  return `"${fieldName}": new FormControl(${value}, [${makeFieldRules(fieldName, definition)}])`;
 }
 
 function makeFieldsBody(definition: Definition): string[] {


### PR DESCRIPTION
Currently, the OpenAPI support default value specification, although it's more intended to be
treated as an optional field and is better handled on the server side. Still, there might be cases
where this could be appropriate to be set as default in the client side, for example, having a
country form value set as `Singapore`, since most of our users are from `Singapore`.